### PR TITLE
Change postgresql keys to new valid keys for Cloudlaunch chart values

### DIFF
--- a/cloudman/values.yaml
+++ b/cloudman/values.yaml
@@ -173,9 +173,9 @@ cloudlaunch:
       oidc_public_uri: "{{.Values.ingress.protocol }}://{{ .Values.global.domain | default (index .Values.ingress.hosts 0) }}/cloudman"
     postgresql:
       enabled: true
-      postgresDatabase: cloudman
-      postgresUser: cloudman
-      postgresPassword: some_pass
+      postgresqlDatabase: cloudman
+      postgresqlUsername: cloudman
+      postgresqlPassword: some_pass
     ingress:
       enabled: true
       path: /cloudman


### PR DESCRIPTION
Noticed that these values were being ignored (`cloudlaunch` user in pod envs instead of `cloudman`) then noticed that the keys were not changed from the old ones