### PR TITLE
projman before helmsman load configs

### DIFF
--- a/cloudman/requirements.yaml
+++ b/cloudman/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
     version: 6.0.0
   - name: prometheus-operator
     repository: https://kubernetes-charts.storage.googleapis.com/
-    version: 8.5.14
+    version: 8.5.15
     alias: prometheus
   - name: influxdb
     repository: https://kubernetes-charts.storage.googleapis.com/

--- a/cloudman/values.yaml
+++ b/cloudman/values.yaml
@@ -7,7 +7,7 @@ admin_email: "cloudman@someplace.org"
 
 projman_config:
   projects:
-    - name: default
+    - name: initial
 
 helmsman_config:
   repositories:
@@ -24,7 +24,7 @@ helmsman_config:
           size: 15000
     galaxy:
       name: cloudve/galaxy
-      namespace: default
+      namespace: initial
       oidc_client:
         client_id: 'galaxy-auth'
         # The client secret is required if the client is not public
@@ -80,7 +80,7 @@ helmsman_config:
           persistence:
             storageClass: ebs
         ingress:
-          path: /default/galaxy
+          path: /initial/galaxy
 
 #    version:
 
@@ -127,8 +127,8 @@ cloudlaunch:
         #!/bin/sh
         /app/venv/bin/python manage.py import_cloud_data /app/secrets/cm_initial_cluster_data.yaml
         /app/venv/bin/python manage.py create_cluster {{ .Values.global.deployment_name | default .Release.Name }} KUBE_RANCHER /app/secrets/cm_initial_cluster_data.yaml
-        /app/venv/bin/python manage.py helmsman_load_config /opt/cloudman/helmsman_config.yaml
         /app/venv/bin/python manage.py projman_load_config /opt/cloudman/projman_config.yaml
+        /app/venv/bin/python manage.py helmsman_load_config /opt/cloudman/helmsman_config.yaml
     extra_config_mounts:
       - name: cloudman-extra-config
         mount_path: /opt/cloudman/


### PR DESCRIPTION
Changed default project to `initial`
Projman needs to create the projects (`initial`) from projman config before helmsman install charts in that namespace.
Part of moving to helm 3 with https://github.com/CloudVE/cloudman-boot/pull/10 and https://github.com/galaxyproject/cloudman/pull/105