### PR TITLE
Keycloak password through secret

### DIFF
--- a/cloudman/data/update_keycloak.sh
+++ b/cloudman/data/update_keycloak.sh
@@ -3,11 +3,9 @@
 # abort if any command fails
 set -e
 username="admin"
-{{- $message := "You must specify a password for Keycloak with --set keycloak.keycloak.password='mypassword' or by setting the key in a custom values.yaml" }}
-password="{{ required $message .Values.keycloak.keycloak.password }}"
 
 # get auth token
-token=$(curl -k -s -d "client_id=admin-cli" -d "username=$username" -d "password=$password" -d "grant_type=password" \
+token=$(curl -k -s -d "client_id=admin-cli" -d "username=$username" -d "password=$KEYCLOAK_HTTP_PASSWORD" -d "grant_type=password" \
        "{{ include "cloudman.root_url" . }}/auth/realms/master/protocol/openid-connect/token" | jq -r '.access_token')
 
 # Get current brute force protection status
@@ -60,7 +58,7 @@ if [ -z "$cloudman_client" ]
 then
       cloudman_client=$(cat <<EOF
 {
-    "clientId": "{{ .Values.cloudlaunch.cloudlaunchserver.extra_env.oidc_client_id }}",
+    "clientId": "$OIDC_CLIENT_ID",
     "rootUrl": "{{ include "cloudman.root_url" . }}/cloudman",
     "adminUrl": "{{ include "cloudman.root_url" . }}/cloudman",
     "enabled": true,
@@ -81,7 +79,7 @@ then
             "protocolMapper": "oidc-audience-mapper",
             "consentRequired": false,
             "config": {
-                "included.client.audience": "{{ .Values.cloudlaunch.cloudlaunchserver.extra_env.oidc_client_id }}",
+                "included.client.audience": "$OIDC_CLIENT_ID",
                 "id.token.claim": "false",
                 "access.token.claim": "true"
             }

--- a/cloudman/templates/cloudman-secrets.yaml
+++ b/cloudman/templates/cloudman-secrets.yaml
@@ -44,3 +44,4 @@ stringData:
   {{ range $path, $bytes := .Files.Glob "data/keycloak_initdb.sh" }}
     {{- base $path }}: {{ tpl ($root.Files.Get $path) $ | quote }}
   {{ end }}
+---

--- a/cloudman/values.yaml
+++ b/cloudman/values.yaml
@@ -147,6 +147,14 @@ cloudlaunch:
           - name: kc-init
             mountPath: /kc-init
             readOnly: true
+        env:
+          - name: OIDC_CLIENT_ID
+            value: "cloudman"
+          - name: KEYCLOAK_HTTP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Release.Name }}-keycloak-http"
+                key: password
     # TODO: include release name in configmap name
     extraVolumes: |
       - name: kubeconfig
@@ -158,10 +166,19 @@ cloudlaunch:
       - name: kubeconfig
         mountPath: /home/cloudman
     extra_env:
-      oidc_enabled: "True"
-      oidc_auth_uri: "{{.Values.ingress.protocol }}://{{ .Values.global.domain | default (index .Values.ingress.hosts 0) }}/auth/realms/master"
-      oidc_client_id: "cloudman"
-      oidc_public_uri: "{{.Values.ingress.protocol }}://{{ .Values.global.domain | default (index .Values.ingress.hosts 0) }}/cloudman"
+      - name: OIDC_ENABLED
+        value: "True"
+      - name: OIDC_AUTH_URI
+        value: "{{.Values.ingress.protocol}}://{{.Values.global.domain | default (index .Values.ingress.hosts 0)}}/auth/realms/master"
+      - name: OIDC_CLIENT_ID
+        value: "cloudman"
+      - name: OIDC_PUBLIC_URI
+        value: "{{.Values.ingress.protocol}}://{{.Values.global.domain | default (index .Values.ingress.hosts 0)}}/cloudman"
+      - name: KEYCLOAK_HTTP_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: "{{ .Release.Name }}-keycloak-http"
+            key: password
     postgresql:
       enabled: true
       postgresqlDatabase: cloudman

--- a/cloudman/values.yaml
+++ b/cloudman/values.yaml
@@ -174,11 +174,6 @@ cloudlaunch:
         value: "cloudman"
       - name: OIDC_PUBLIC_URI
         value: "{{.Values.ingress.protocol}}://{{.Values.global.domain | default (index .Values.ingress.hosts 0)}}/cloudman"
-      - name: KEYCLOAK_HTTP_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: "{{ .Release.Name }}-keycloak-http"
-            key: password
     postgresql:
       enabled: true
       postgresqlDatabase: cloudman


### PR DESCRIPTION
Passing Keycloak's admin user password through env from secret generated by Keycloak, and OIDC client through env variable as well. Also changed `extra_env` to take any type of env, rather than just values.
Goes with https://github.com/CloudVE/cloudlaunch-helm/pull/10/files