### PR TITLE
Reauired influxdb.setDefaultUser.password

### DIFF
--- a/cloudman/templates/grafana-datasource-secret.yaml
+++ b/cloudman/templates/grafana-datasource-secret.yaml
@@ -26,5 +26,6 @@ stringData:
       editable: false
       database: {{ include "cloudman.influxdb_database" . }}
       user: {{ .Values.influxdb.setDefaultUser.username }}
-      password: {{ .Values.influxdb.setDefaultUser.password }}
+      password: {{$message := "`influxdb.setDefaultUser.password` is a required value"}}
+                {{- required $message .Values.influxdb.setDefaultUser.password }}
       editable: false

--- a/cloudman/values.yaml
+++ b/cloudman/values.yaml
@@ -271,7 +271,7 @@ influxdb:
   setDefaultUser:
     enabled: true
     username: "admin"
-    password: "changeme"
+    # password: "iAmRequired"
   initScripts:
     enabled: true
   persistence:


### PR DESCRIPTION
At least for the time being, just make the value required since it's also passed to Galaxy config, so randomizing requires a bit of change