### PR TITLE
Removing default nginx ingress class

### DIFF
--- a/cloudman/values.yaml
+++ b/cloudman/values.yaml
@@ -104,8 +104,8 @@ cloudlaunch:
 
   ingress:
     enabled: true
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
     path: /
     hosts:
       - ~


### PR DESCRIPTION
This default is sensible when we setup nginx ingress, but for managed clusters (eg: GKE) it can interfere with the automatic GKE ingress, and given the nature of the value it's hard to unset, so figured it'd be ideal to not have it as a default here, and just add it to the app-registry for GVL: https://github.com/galaxyproject/cloudlaunch-registry/pull/15/files