### PR TITLE
Galaxy changes for import library

### DIFF
--- a/cloudman/values.yaml
+++ b/cloudman/values.yaml
@@ -74,7 +74,8 @@ helmsman_config:
       info_url: https://galaxyproject.org/
       icon_url: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
       context:
-        oidc_client_secret: '{{ .Values.oidc_clients.galaxy.client_secret}}'
+        oidc_client_secret: '{{ .Values.oidc_clients.galaxy.client_secret }}'
+        oidc_client_id: '{{ .Values.oidc_clients.galaxy.client_id }}'
         domain: '{{ .Values.global.domain }}'
         influxdb_url: '{{ include "cloudman.influxdb_url_cluster" . }}'
         influxdb_database: '{{ include "cloudman.influxdb_database" . }}'
@@ -94,7 +95,7 @@ helmsman_config:
             <OIDC>
                 <provider name="custos">
                     <url>https://{{context.domain}}/auth</url>
-                    <client_id>galaxy-auth</client_id>
+                    <client_id>{{context.oidc_client_id}}</client_id>
                     <client_secret>{{context.oidc_client_secret}}</client_secret>
                     <redirect_uri>https://{{context.domain}}/{{context.project.namespace}}/galaxy/authnz/custos/callback</redirect_uri>
                     <enable_idp_logout>true</enable_idp_logout>

--- a/cloudman/values.yaml
+++ b/cloudman/values.yaml
@@ -107,6 +107,10 @@ helmsman_config:
               </auth>
           galaxy.yml:
             galaxy:
+              library_import_dir: /gvl
+              user_library_import_dir: /gvl
+              admin_users: cloudman@someplace.org
+              allow_path_paste: true
               enable_oidc: true
               oidc_config_file: /galaxy/server/config/oidc_config.xml
               oidc_backends_config_file: /galaxy/server/config/oidc_backends_config.xml

--- a/cloudman/values.yaml
+++ b/cloudman/values.yaml
@@ -81,6 +81,7 @@ helmsman_config:
         influxdb_database: '{{ include "cloudman.influxdb_database" . }}'
         influxdb_username: '{{ .Values.influxdb.setDefaultUser.username }}'
         influxdb_password: '{{ .Values.influxdb.setDefaultUser.password }}'
+        admin_users: cloudman@someplace.org
       template: |
         configs:
           oidc_config.xml: |
@@ -109,7 +110,7 @@ helmsman_config:
             galaxy:
               library_import_dir: /gvl
               user_library_import_dir: /gvl
-              admin_users: cloudman@someplace.org
+              admin_users: {{context.admin_users}}
               allow_path_paste: true
               enable_oidc: true
               oidc_config_file: /galaxy/server/config/oidc_config.xml


### PR DESCRIPTION
Adds Galaxy settings for enabling data libraries in GVL. Also rolled in using context and CM values to pass the OIDC client ID for Galaxy, like the other apps, instead of having it hardcoded.