### PR TITLE
Downgrade kube prometheus to a working version

### DIFF
--- a/cloudman/requirements.yaml
+++ b/cloudman/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     version: 0.4.0
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 16.7.0
+    version: 12.3.0
     alias: kubeprometheus
   - name: influxdb
     repository: https://charts.helm.sh/stable


### PR DESCRIPTION
Operator v0.43 works (chart version 12.3.0), but alert manager configs in operator v0.44 onwards is broken. However, the latest operator version also works, but it cannot be used because kube-state-metrics has been upgraded to v2.0.0, which changes some metric names and breaks autoscaling.